### PR TITLE
[TestTargetMaster] Fix managementgroup output-folders in go SDK

### DIFF
--- a/specification/managementgroups/resource-manager/readme.go.md
+++ b/specification/managementgroups/resource-manager/readme.go.md
@@ -27,7 +27,7 @@ These settings apply only when `--tag=package-2020-05 --go` is specified on the 
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
 ``` yaml $(tag)=='package-2020-05' && $(go)
-output-folder: $(go-sdk-folder)/services/preview/resources/mgmt/2020-05-01/$(namespace)
+output-folder: $(go-sdk-folder)/services/resources/mgmt/2020-05-01/$(namespace)
 ```
 
 ### Tag: package-2020-02 and go
@@ -36,7 +36,7 @@ These settings apply only when `--tag=package-2020-02 --go` is specified on the 
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
 ``` yaml $(tag)=='package-2020-02' && $(go)
-output-folder: $(go-sdk-folder)/services/preview/resources/mgmt/2020-02-01/$(namespace)
+output-folder: $(go-sdk-folder)/services/resources/mgmt/2020-02-01/$(namespace)
 ```
 
 ### Tag: package-2019-11 and go
@@ -45,7 +45,7 @@ These settings apply only when `--tag=package-2019-11 --go` is specified on the 
 Please also specify `--go-sdk-folder=<path to the root directory of your azure-sdk-for-go clone>`.
 
 ``` yaml $(tag)=='package-2019-11' && $(go)
-output-folder: $(go-sdk-folder)/services/preview/resources/mgmt/2019-11-01/$(namespace)
+output-folder: $(go-sdk-folder)/services/resources/mgmt/2019-11-01/$(namespace)
 ```
 
 ### Tag: package-2018-03 and go


### PR DESCRIPTION
Mirror from `https://github.com/Azure/azure-rest-api-specs/pull/10591`