### PR TITLE
weidongtest cdn: adding missing `x-ms-enum`'s

### DIFF
--- a/specification/cdn/resource-manager/Microsoft.Cdn/stable/2021-06-01/cdn.json
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/stable/2021-06-01/cdn.json
@@ -3358,7 +3358,11 @@
               "DELETE",
               "OPTIONS",
               "TRACE"
-            ]
+            ],
+            "x-ms-enum": {
+              "name": "RequestMethodMatchValues",
+              "modelAsString": false
+            }
           }
         }
       }
@@ -3675,7 +3679,11 @@
             "enum": [
               "HTTP",
               "HTTPS"
-            ]
+            ],
+            "x-ms-enum": {
+              "name": "RequestSchemeMatchValues",
+              "modelAsString": false
+            }
           }
         }
       }
@@ -3977,7 +3985,11 @@
             "enum": [
               "Mobile",
               "Desktop"
-            ]
+            ],
+            "x-ms-enum": {
+              "name": "DeviceMatchConditionValues",
+              "modelAsString": false
+            }
           }
         },
         "transforms": {


### PR DESCRIPTION
Mirror from `https://github.com/Azure/azure-rest-api-specs/pull/17987`