### PR TITLE
weidongtest Blob Storage - Remove regex pattern constraint from blob name parameter

### DIFF
--- a/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-10-02/blob.json
+++ b/specification/storage/data-plane/Microsoft.BlobStorage/preview/2020-10-02/blob.json
@@ -10922,7 +10922,6 @@
       "in": "path",
       "required": true,
       "type": "string",
-      "pattern": "^[a-zA-Z0-9]+(?:/[a-zA-Z0-9]+)*(?:\\.[a-zA-Z0-9]+){0,1}$",
       "minLength": 1,
       "maxLength": 1024,
       "x-ms-parameter-location": "method",


### PR DESCRIPTION
Mirror from `https://github.com/Azure/azure-rest-api-specs/pull/16081`